### PR TITLE
Add the absent space in YAML example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To install manually without bundler:
 Then add the gem to your Jekyll configuration.
 
     gems:
-      -octopress-debugger
+      - octopress-debugger
 
 ## Usage
 


### PR DESCRIPTION
The YAML example for the Jekyll configuration was lacking a space causing bad syntax, which in turn caused an exception when starting Jekyll:

```
Configuration file: /home/gk/Git/<removed>/_config.yml
/var/lib/gems/2.1.0/gems/jekyll-2.5.3/lib/jekyll/plugin_manager.rb:26:in `require_gems': undefined method `each' for "-octopress-debugger":String (NoMethodError)
	from /var/lib/gems/2.1.0/gems/jekyll-2.5.3/lib/jekyll/plugin_manager.rb:19:in `conscientious_require'
	from /var/lib/gems/2.1.0/gems/jekyll-2.5.3/lib/jekyll/site.rb:79:in `setup'
	from /var/lib/gems/2.1.0/gems/jekyll-2.5.3/lib/jekyll/site.rb:41:in `initialize'
	from /var/lib/gems/2.1.0/gems/jekyll-2.5.3/lib/jekyll/commands/build.rb:29:in `new'
	from /var/lib/gems/2.1.0/gems/jekyll-2.5.3/lib/jekyll/commands/build.rb:29:in `process'
	from /var/lib/gems/2.1.0/gems/jekyll-2.5.3/lib/jekyll/commands/serve.rb:26:in `block (2 levels) in init_with_program'
	from /var/lib/gems/2.1.0/gems/mercenary-0.3.5/lib/mercenary/command.rb:220:in `call'
	from /var/lib/gems/2.1.0/gems/mercenary-0.3.5/lib/mercenary/command.rb:220:in `block in execute'
	from /var/lib/gems/2.1.0/gems/mercenary-0.3.5/lib/mercenary/command.rb:220:in `each'
	from /var/lib/gems/2.1.0/gems/mercenary-0.3.5/lib/mercenary/command.rb:220:in `execute'
	from /var/lib/gems/2.1.0/gems/mercenary-0.3.5/lib/mercenary/program.rb:42:in `go'
	from /var/lib/gems/2.1.0/gems/mercenary-0.3.5/lib/mercenary.rb:19:in `program'
	from /var/lib/gems/2.1.0/gems/jekyll-2.5.3/bin/jekyll:20:in `<top (required)>'
	from /usr/local/bin/jekyll:23:in `load'
	from /usr/local/bin/jekyll:23:in `<main>'
```